### PR TITLE
Example that fails to build

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,10 @@
 (executable
  (name rust_ocaml_starter)
  (public_name rust-ocaml-starter)
- (libraries zarith)
+ ; Optional: Depend on a library that links in a C library:
+ ; (libraries zarith)
+ ; If you get a linking error, e.g. `ld: cannot find -lgmp: No such file or
+ ; directory` and are on Linux, you may need to explicitly provide the
+ ; following flags:
+ ; (flags -cclib -L/usr/lib/x86_64-linux-gnu)
  (modes exe object))

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,5 @@
 (executable
  (name rust_ocaml_starter)
  (public_name rust-ocaml-starter)
+ (libraries zarith)
  (modes exe object))


### PR DESCRIPTION
Adding a dependency on `zarith`, which in turn depends on `libgmp`, causes `dune build` to fail with `ld: cannot find -lgmp: No such file or directory`.
(To reproduce you must first `opam install zarith`.)

Can you tell me how to fix this, and I'll add it as an example?

Thanks!